### PR TITLE
allow adding custom options to guzzle

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@ See [API Docs](http://leadcommercede.github.io/shopware-sdk/)
     
     // Create a new client
     $client = new ShopwareClient('http://shopware.dev/api/', 'user', 'api_key');
+
+    /**
+     * set custom options for guzzle
+     * the official guzzle documentation contains a list of valid options (http://docs.guzzlephp.org/en/latest/request-options.html) 
+     */  
+    //$client = new ShopwareClient('http://shopware.dev/api/', 'user', 'api_key', ['cert' => ['/path/server.pem']]);
     
     // Fetch all articles
     $articles = $client->getArticleQuery()->findAll();

--- a/src/LeadCommerce/Shopware/SDK/ShopwareClient.php
+++ b/src/LeadCommerce/Shopware/SDK/ShopwareClient.php
@@ -76,17 +76,19 @@ class ShopwareClient
      * @param null $username
      * @param null $apiKey
      */
-    public function __construct($baseUrl, $username = null, $apiKey = null)
+    public function __construct($baseUrl, $username = null, $apiKey = null, array $guzzleOptions = [])
     {
         $this->baseUrl = $baseUrl;
         $this->username = $username;
         $this->apiKey = $apiKey;
         $curlHandler = new CurlHandler();
         $handlerStack = HandlerStack::create($curlHandler);
-        $this->client = new Client([
+
+        $guzzleOptions = array_merge($guzzleOptions, [
             'base_uri' => $this->baseUrl,
             'handler'  => $handlerStack
         ]);
+        $this->client = new Client($guzzleOptions);
     }
 
     /**

--- a/src/LeadCommerce/Shopware/SDK/ShopwareClient.php
+++ b/src/LeadCommerce/Shopware/SDK/ShopwareClient.php
@@ -86,7 +86,7 @@ class ShopwareClient
 
         $guzzleOptions = array_merge($guzzleOptions, [
             'base_uri' => $this->baseUrl,
-            'handler'  => $handlerStack
+            'handler'  => $handlerStack,
         ]);
         $this->client = new Client($guzzleOptions);
     }


### PR DESCRIPTION
Currently it is not possible to add custom options to the used guzzle client.

This pr gives the option to pass a third, optional paramater ``$guzzleOptions`` to ``ShopwareClient`` ``_construct``.
The array is merged with the default options for ``base_uri`` and  ``handler``.

This is not a BC-break since the additional parameter is optional an by default an array.

