### PR TITLE
Bugfix empty array values

### DIFF
--- a/src/LeadCommerce/Shopware/SDK/Entity/Base.php
+++ b/src/LeadCommerce/Shopware/SDK/Entity/Base.php
@@ -54,6 +54,11 @@ class Base
                 }
             }
         }
+
+        $array = array_filter($array, function ($value) {
+            return $value !== null;
+        });
+
         return $array;
     }
 

--- a/tests/LeadCommerce/Tests/Unit/Entity/ArticleTest.php
+++ b/tests/LeadCommerce/Tests/Unit/Entity/ArticleTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace LeadCommerce\Tests\Unit;
+
+use LeadCommerce\Shopware\SDK\Entity\Article;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class ArticleTest
+ * @package LeadCommerce\Tests\Unit
+ */
+class ArticleTest extends TestCase
+{
+    public function testThatArrayCopyDoesNotReturnArrayElementsWithNullValue()
+    {
+        $attributes['id'] = 1;
+        $attributes['name'] = 'foo';
+        $attributes['taxId'] = null;
+
+        $entity = new Article();
+        $entity->setEntityAttributes($attributes);
+        $arrayCopy = $entity->getArrayCopy();
+
+        static::assertArrayNotHasKey('taxId', $arrayCopy);
+        static::assertArrayHasKey('name', $arrayCopy);
+        static::assertArrayHasKey('id', $arrayCopy);
+    }
+}


### PR DESCRIPTION
Fixes bug which occur when we trying to POST or PUT entity with empty value (which means the array value is "null")

Sometimes Shopware has a problem when you try to post an array with some null values. We fix this by complete unsetting the array elements with null value.